### PR TITLE
:bug: fix:User schema required

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -345,6 +345,9 @@ components:
           example: 'https://gravatar.com/avatar/3cb5628734a944573d67a5871b1dcbfb?s=400&d=robohash&r=x'
       required:
         - id
+        - username
+        - email
+        - avatarUrl
     Todo:
       title: Todo
       type: object


### PR DESCRIPTION
## 概要
- User schemaの必須フィールドが漏れていたので追加をした

redocですと、下記の画像のusernameとかが必須になります。（絶対に返却される値）
code-genとかで型を自動生成した場合も必須にしていないとnull許容の型になります。

※共有しているredocはマージしたタイミングでgithub actionsが動き、更新されるはずです（たぶん）
![image](https://user-images.githubusercontent.com/65271262/156482938-fc32ef8c-910b-4647-b751-8c28f8ba777f.png)
